### PR TITLE
subprocess error handling for generated/execute commands

### DIFF
--- a/tkltest/generate/generate_standalone.py
+++ b/tkltest/generate/generate_standalone.py
@@ -18,7 +18,7 @@ import subprocess
 import sys
 import json
 
-from tkltest.util import constants, build_util
+from tkltest.util import constants, build_util, command_util
 from tkltest.util.logging_util import tkltest_status
 
 
@@ -55,9 +55,9 @@ def generate_evosuite(config):
     evosuite_command += evosuite_flags
     logging.info(evosuite_command)
     try:
-        subprocess.run(evosuite_command, capture_output=not config['general']['verbose'], shell=True, check=True)
+        command_util.run_command(command=evosuite_command, verbose=config['general']['verbose'])
     except subprocess.CalledProcessError as e:
-        tkltest_status('Generating test suite using Evosuite failed: {}'.format(e), error=True)
+        tkltest_status('Generating test suite using Evosuite failed: {}\n{}'.format(e, e.stderr), error=True)
         sys.exit(1)
     tkltest_status('Generated Evosuite test suite written to {}'.format(output_dir))
 
@@ -126,9 +126,9 @@ def generate_randoop(config):
     randoop_command += __get_randoop_flags(config, time_limit)
     logging.info(randoop_command)
     try:
-        subprocess.run(randoop_command, capture_output=not config['general']['verbose'], shell=True, check=True)
+        command_util.run_command(command=randoop_command, verbose=config['general']['verbose'])
     except subprocess.CalledProcessError as e:
-        tkltest_status('Generating test suite using Randoop failed: {}'.format(e), error=True)
+        tkltest_status('Generating test suite using Randoop failed: {}\n{}'.format(e, e.stderr), error=True)
         sys.exit(1)
     tkltest_status('Generated Randoop test suite written to {}'.format(output_dir))
 

--- a/tkltest/util/command_util.py
+++ b/tkltest/util/command_util.py
@@ -1,0 +1,40 @@
+# ***************************************************************************
+# Copyright IBM Corporation 2021
+#
+# Licensed under the Eclipse Public License 2.0, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ***************************************************************************
+
+import subprocess
+import sys
+
+
+def run_command(command, verbose, env_vars=None):
+    """Runs a command using subprocess.
+
+    Runs the given command using subprocess.run(). If verbose is false, stdout is
+    discarded. A pipe is opened to stderr of the subprocess so that the subprocess
+    error messages can be captured and printed by the CLI if the command fails.
+    If env_vars is specified, the command is executed under the given environment
+    variable values
+    """
+    if verbose:
+        if env_vars:
+            subprocess.run(command, shell=True, check=True, stderr=subprocess.PIPE, env=env_vars,
+                           encoding=sys.getfilesystemencoding())
+        else:
+            subprocess.run(command, shell=True, check=True, stderr=subprocess.PIPE,
+                           encoding=sys.getfilesystemencoding())
+    else:
+        if env_vars:
+            subprocess.run(command, shell=True, check=True, stdout=subprocess.DEVNULL,
+                           stderr=subprocess.PIPE, env=env_vars, encoding=sys.getfilesystemencoding())
+        else:
+            subprocess.run(command, shell=True, check=True, stdout=subprocess.DEVNULL,
+                           stderr=subprocess.PIPE, encoding=sys.getfilesystemencoding())


### PR DESCRIPTION
## Description

Updated calls to subprocess.run so that the stderr of the command is
captured and printed by the CLI if the command fails; added command_util
module with run method that is called from generate and execute modules.

Related to # (issue)

## Type of Change

Please check the types of changes your PR introduces.

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Refactoring (non-breaking code restructuring that preserves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build-related update (CI workflow, test cases)
- [ ] Documentation update
- [ ] Other (please describe):

## How Has This Been Tested?

Tested locally with injected failures in generated/execute commands and using CI tests.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
