### PR TITLE
Issue 63 take2 runninig only the extender on another dir

### DIFF
--- a/tkltest/generate/generate.py
+++ b/tkltest/generate/generate.py
@@ -239,7 +239,9 @@ def generate_CTD_models_and_test_plans(app_name, partitions_file, target_class_l
     modeling_command += os.path.join(constants.TKLTEST_LIB_DOWNLOAD_DIR, "heros-1.2.0.jar") + os.pathsep
     modeling_command += os.path.join(constants.TKLTEST_LIB_DOWNLOAD_DIR, "httpcore-4.4.6.jar") + os.pathsep
     modeling_command += os.path.join(constants.TKLTEST_LIB_DOWNLOAD_DIR, "httpclient-4.5.13.jar") + os.pathsep
-    modeling_command += os.path.join(constants.TKLTEST_LIB_DOWNLOAD_DIR, "javax.json-1.0.4.jar")
+    modeling_command += os.path.join(constants.TKLTEST_LIB_DOWNLOAD_DIR, "jackson-databind-2.12.5.jar") + os.pathsep
+    modeling_command += os.path.join(constants.TKLTEST_LIB_DOWNLOAD_DIR, "jackson-core-2.12.5.jar") + os.pathsep
+    modeling_command += os.path.join(constants.TKLTEST_LIB_DOWNLOAD_DIR, "jackson-annotations-2.12.5.jar")
     modeling_command += " org.konveyor.tackle.testgen.model.CTDTestPlanGenerator "
     modeling_command += " -app "+app_name
     if partitions_file:
@@ -299,7 +301,9 @@ def run_bb_test_generator(app_name, ctd_file, monolith_app_path, app_classpath_f
     tg_command += os.path.join(constants.TKLTEST_LIB_DOWNLOAD_DIR, "javaparser-symbol-solver-core-3.16.1.jar") + os.pathsep
     tg_command += os.path.join(constants.TKLTEST_LIB_DOWNLOAD_DIR, "guava-29.0-jre.jar") + os.pathsep
     tg_command += os.path.join(constants.TKLTEST_LIB_DOWNLOAD_DIR, "failureaccess-1.0.1.jar") + os.pathsep
-    tg_command += os.path.join(constants.TKLTEST_LIB_DOWNLOAD_DIR, "javax.json-1.0.4.jar")
+    tg_command += os.path.join(constants.TKLTEST_LIB_DOWNLOAD_DIR, "jackson-databind-2.12.5.jar") + os.pathsep
+    tg_command += os.path.join(constants.TKLTEST_LIB_DOWNLOAD_DIR, "jackson-core-2.12.5.jar") + os.pathsep
+    tg_command += os.path.join(constants.TKLTEST_LIB_DOWNLOAD_DIR, "jackson-annotations-2.12.5.jar")
     tg_command += " org.konveyor.tackle.testgen.core.TestSequenceInitializer"
     tg_command += " -app " + app_name
     tg_command += " -tp " + ctd_file
@@ -362,7 +366,9 @@ def extend_sequences(app_name, monolith_app_path, app_classpath_file, ctd_file, 
         te_command += os.path.join(constants.TKLTEST_LIB_DIR,
                                    "evosuite-standalone-runtime-"+constants.EVOSUITE_VERSION+"-SNAPSHOT.jar") + os.pathsep
         te_command += os.path.join(constants.TKLTEST_LIB_DOWNLOAD_DIR, "junit-4.13.1.jar") + os.pathsep
-    te_command += os.path.join(constants.TKLTEST_LIB_DOWNLOAD_DIR, "javax.json-1.0.4.jar") + os.pathsep
+    te_command += os.path.join(constants.TKLTEST_LIB_DOWNLOAD_DIR, "jackson-databind-2.12.5.jar") + os.pathsep
+    te_command += os.path.join(constants.TKLTEST_LIB_DOWNLOAD_DIR, "jackson-core-2.12.5.jar") + os.pathsep
+    te_command += os.path.join(constants.TKLTEST_LIB_DOWNLOAD_DIR, "jackson-annotations-2.12.5.jar") + os.pathsep
     te_command += os.path.join(constants.TKLTEST_LIB_DOWNLOAD_DIR, "commons-cli-1.4.jar") + os.pathsep
     te_command += os.path.join(constants.TKLTEST_LIB_DOWNLOAD_DIR, "commons-io-2.6.jar") + os.pathsep
     te_command += os.path.join(constants.TKLTEST_LIB_DOWNLOAD_DIR, "javaparser-core-3.16.1.jar") + os.pathsep

--- a/tkltest/generate/generate.py
+++ b/tkltest/generate/generate.py
@@ -136,16 +136,17 @@ def generate_ctd_amplified_tests(config):
     else:
         test_directory = config['general']['test_directory']
 
+    tmp_test_directory = test_directory + constants.TKLTEST_TEMP_DIR_SUFFIX
     # generate extended test sequences
     extend_sequences(app_name, monolith_app_path, app_classpath_file, ctd_file, bb_seq_file, jdk_path,
                      config['generate']['no_diff_assertions'],
                      config['generate']['jee_support'],
                      config['generate']['ctd_amplified']['num_seq_executions'],
-                     test_directory + constants.TKLTEST_TEMP_DIR_SUFFIX, verbose)
-    if True: #todo - extend success
-        if os.path.exists(test_directory):
-            shutil.rmtree(test_directory)
-        os.rename(test_directory + constants.TKLTEST_TEMP_DIR_SUFFIX, test_directory)
+                     tmp_test_directory, verbose)
+
+    if os.path.exists(test_directory):
+        shutil.rmtree(test_directory)
+    os.rename(tmp_test_directory, test_directory)
 
     tkltest_status("Extending test sequences and writing junit tests took " +
                  str(round(time.time() - start_time, 2)) + " seconds")
@@ -454,19 +455,21 @@ def generate_ctd_coverage(ctd_report_file_abs, ctd_model_file_abs, report_output
 def __reset_test_directory(args, config):
     # clear contents of test directory
     test_directory = config['general']['test_directory']
-    dir_suffix = ""
     if test_directory == '':
         app_name = config['general']['app_name']
         if args.sub_command == "ctd-amplified":
             test_directory = app_name + constants.TKLTEST_DEFAULT_CTDAMPLIFIED_TEST_DIR_SUFFIX
-            dir_suffix = constants.TKLTEST_TEMP_DIR_SUFFIX
         elif args.sub_command == "randoop":
             test_directory = app_name + constants.TKLTEST_DEFAULT_RANDOOP_TEST_DIR_SUFFIX
         elif args.sub_command == "evosuite":
             test_directory = app_name + constants.TKLTEST_DEFAULT_EVOSUITE_TEST_DIR_SUFFIX
 
-    shutil.rmtree(test_directory + dir_suffix, ignore_errors=True)
-    os.mkdir(test_directory + dir_suffix)
+    directory_to_reset = test_directory;
+    if args.sub_command == "ctd-amplified":
+        directory_to_reset = directory_to_reset + constants.TKLTEST_TEMP_DIR_SUFFIX
+
+    shutil.rmtree(directory_to_reset, ignore_errors=True)
+    os.mkdir(directory_to_reset)
     return test_directory
 
 

--- a/tkltest/generate/generate.py
+++ b/tkltest/generate/generate.py
@@ -141,7 +141,11 @@ def generate_ctd_amplified_tests(config):
                      config['generate']['no_diff_assertions'],
                      config['generate']['jee_support'],
                      config['generate']['ctd_amplified']['num_seq_executions'],
-                     test_directory, verbose)
+                     test_directory + constants.TKLTEST_TEMP_DIR_SUFFIX, verbose)
+    if True: #todo - extend success
+        if os.path.exists(test_directory):
+            shutil.rmtree(test_directory)
+        os.rename(test_directory + constants.TKLTEST_TEMP_DIR_SUFFIX, test_directory)
 
     tkltest_status("Extending test sequences and writing junit tests took " +
                  str(round(time.time() - start_time, 2)) + " seconds")
@@ -444,17 +448,19 @@ def generate_ctd_coverage(ctd_report_file_abs, ctd_model_file_abs, report_output
 def __reset_test_directory(args, config):
     # clear contents of test directory
     test_directory = config['general']['test_directory']
+    dir_suffix = ""
     if test_directory == '':
         app_name = config['general']['app_name']
         if args.sub_command == "ctd-amplified":
             test_directory = app_name + constants.TKLTEST_DEFAULT_CTDAMPLIFIED_TEST_DIR_SUFFIX
+            dir_suffix = constants.TKLTEST_TEMP_DIR_SUFFIX
         elif args.sub_command == "randoop":
             test_directory = app_name + constants.TKLTEST_DEFAULT_RANDOOP_TEST_DIR_SUFFIX
         elif args.sub_command == "evosuite":
             test_directory = app_name + constants.TKLTEST_DEFAULT_EVOSUITE_TEST_DIR_SUFFIX
 
-    shutil.rmtree(test_directory, ignore_errors=True)
-    os.mkdir(test_directory)
+    shutil.rmtree(test_directory + dir_suffix, ignore_errors=True)
+    os.mkdir(test_directory + dir_suffix)
     return test_directory
 
 

--- a/tkltest/util/constants.py
+++ b/tkltest/util/constants.py
@@ -36,7 +36,10 @@ TKLTEST_DEFAULT_RANDOOP_TEST_DIR_SUFFIX = "-randoop-standalone-tests"
 # EvoSuite standalone tests
 TKLTEST_DEFAULT_EVOSUITE_TEST_DIR_SUFFIX = "-evosuite-standalone-tests"
 
-# suffix for the directory containing test reports (CTD, junit, jacoco); names of the 
+# suffix for the temporary test directory name
+TKLTEST_TEMP_DIR_SUFFIX = "-tkltest-tmp"
+
+# suffix for the directory containing test reports (CTD, junit, jacoco); names of the
 # sub-directories for different reports
 TKLTEST_MAIN_REPORT_DIR_SUFFIX = '-tkltest-reports'
 TKL_CTD_REPORT_DIR = 'ctd-report'


### PR DESCRIPTION
## Description

in case of failure, we want to keep the old testing.
so, we let the extender run on a temporary directory.
after the extender finish successfully, we will copy the testing to the testing directory
Related to # (63)

## Type of Change

Please check the types of changes your PR introduces.

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x ] New feature (non-breaking change that adds functionality)
- [ ] Refactoring (non-breaking code restructuring that preserves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build-related update (CI workflow, test cases)
- [ ] Documentation update
- [ ] Other (please describe):

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so that it can be replicated.
Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
