### PR TITLE
Fixed CLI crash when no args passed or no config file specified #89

### DIFF
--- a/test/test_cli.bats
+++ b/test/test_cli.bats
@@ -16,6 +16,12 @@ teardown_file() {
     rm -f $TEST_CONFIG_FILE1 $TEST_CONFIG_FILE2
 }
 
+@test "Test 00: CLI main no args" {
+    run tkltest
+    [ $status -eq 0 ]
+    [ "${lines[0]}" = "usage: tkltest [-h] [-cf CONFIG_FILE] [-l {CRITICAL,ERROR,WARNING,INFO,DEBUG}]" ]
+}
+
 @test "Test 01: CLI main help" {
     run tkltest --help
     [ $status -eq 0 ]
@@ -108,7 +114,14 @@ teardown_file() {
     [[ "${lines[3]}" == *"Value for option \"base_test_generator\" must be one of ['combined', 'evosuite', 'randoop']: combine"* ]]
 }
 
-@test "Test 13: CLI generate ctd-amplified invalid spec in toml" {
+@test "Test 13: CLI generate ctd-amplified no config" {
+    run tkltest generate ctd-amplified
+    [ $status -eq 1 ]
+    echo "# ${lines[@]}" >&3
+    [[ "${lines[0]}" == *"ERROR: No config file specified"* ]]
+}
+
+@test "Test 14: CLI generate ctd-amplified invalid spec in toml" {
     run tkltest --config-file $IRS_CONFIG_FILE_ERR \
         generate --partitions-file $IRS_PARTITIONS_FILE ctd-amplified
     [ $status -eq 1 ]
@@ -119,7 +132,7 @@ teardown_file() {
     [[ "${lines[4]}" == *"Value for option \"base_test_generator\" must be one of ['combined', 'evosuite', 'randoop']: combine"* ]]
 }
 
-@test "Test 14: CLI execute invalid spec in toml" {
+@test "Test 15: CLI execute invalid spec in toml" {
     run tkltest --config-file $IRS_CONFIG_FILE_ERR execute
     [ $status -eq 1 ]
     echo "# ${lines[@]}" >&3
@@ -129,7 +142,7 @@ teardown_file() {
     [[ "${lines[4]}" == *"Value for option \"build_type\" must be one of ['ant', 'maven']: gradle"* ]]
 }
 
-@test "Test 15: CLI execute missing generate config" {
+@test "Test 16: CLI execute missing generate config" {
     if [ ! -d $IRS_CTD_AMPLIFIED_TESTDIR ];  then
         echo "# creating $IRS_CTD_AMPLIFIED_TESTDIR" >&3
         mkdir $IRS_CTD_AMPLIFIED_TESTDIR
@@ -146,7 +159,7 @@ teardown_file() {
     [[ "${lines[2]}" == *"To execute tests in ../$IRS_CTD_AMPLIFIED_TESTDIR, the file created by the generate command must be available"* ]]
 }
 
-@test "Test 16: CLI generate ctd-amplified parameter constraint violation" {
+@test "Test 17: CLI generate ctd-amplified parameter constraint violation" {
     run tkltest --config-file $IRS_CONFIG_FILE generate ctd-amplified \
         --base-test-generator randoop --augment-coverage
     [ $status -eq 1 ]

--- a/tkltest/tkltest.py
+++ b/tkltest/tkltest.py
@@ -172,6 +172,11 @@ def main():
     # parse arguments
     args = parser.parse_args()
 
+    # if no args specified, print help message and exit
+    if len(sys.argv) == 1:
+        parser.print_help()
+        sys.exit(0)
+
     # initialize logging
     logging_util.init_logging('./tkltest.log', args.log_level)
     logging.debug('args: {}'.format(args))
@@ -180,6 +185,11 @@ def main():
     if args.command == 'config':
         __process_config_commands(args)
         sys.exit(0)
+
+    # if config file not specified, print help and exit
+    if not args.config_file:
+        logging_util.tkltest_status('No config file specified\n', error=True)
+        sys.exit(1)
 
     # load config file
     logging_util.tkltest_status('Loading config file {}'.format(args.config_file.name))


### PR DESCRIPTION
## Description

Fixed bug that caused the CLI to crash when no args are specified or no config file is specified

Related to #89 

## Type of Change

Please check the types of changes your PR introduces.

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactoring (non-breaking code restructuring that preserves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build-related update (CI workflow, test cases)
- [ ] Documentation update
- [ ] Other (please describe):

## How Has This Been Tested?

Added bats tests for the bug fix; testing using CI test cases.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
