### PR TITLE
Fixing output folder pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,15 +221,15 @@ and executing them. More detailed description is available in the [CLI user guid
    ```
    tkltest --verbose generate ctd-amplified
    ```
-   The unit test cases will be generated in a folder named `tkltest-outdir-<app-name>/<app-name>-ctd-amplified-tests/monolith`.
-   A CTD coverage report will be created as well  in a folder named `tkltest-outdir-<app-name>/<app-name>-tkltest-reports`, showing
+   The unit test cases will be generated in a folder named `tkltest-output-<app-name>/<app-name>-ctd-amplified-tests/monolith`.
+   A CTD coverage report will be created as well  in a folder named `tkltest-output-<app-name>/<app-name>-tkltest-reports`, showing
    the CTD test plan row coverage achieved by the generated tests.
 
 4. To execute the generated unit tests on the legacy app, run the command
    ```
-   tkltest --verbose --test-directory tkltest-outdir-<app-name>/<app-name>-ctd-amplified-tests execute
+   tkltest --verbose --test-directory tkltest-output-<app-name>/<app-name>-ctd-amplified-tests execute
    ```
-   JUnit reports and Jacoco code coverage reports will be created in  `tkltest-outdir-<app-name>/<app-name>-tkltest-reports`.
+   JUnit reports and Jacoco code coverage reports will be created in  `tkltest-output-<app-name>/<app-name>-tkltest-reports`.
  
 Note that, if the `--config-file` option is not specified on the command line (as in the commands above),
 the CLI uses by default `./tkltest_config.toml` as the configuration file.


### PR DESCRIPTION
## Description

Documentation describes that the default folder generated is `tkltest-outdir-` pattern however it is wrong, because the folder generated is `tkltest-output-`. 

This is the default patter described in the source code of the CLI:

https://github.com/konveyor/tackle-test-generator-cli/blob/main/tkltest/util/constants.py#L22

## Type of Change

Please check the types of changes your PR introduces.

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactoring (non-breaking code restructuring that preserves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build-related update (CI workflow, test cases)
- [X] Documentation update
- [ ] Other (please describe):

## How Has This Been Tested?

Follow the instructions to generate the test classes from an application.

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
