### PR TITLE
Fix behavior of reuse_base_tests flag when no sequence files exist

### DIFF
--- a/tkltest/generate/generate.py
+++ b/tkltest/generate/generate.py
@@ -120,7 +120,18 @@ def generate_ctd_amplified_tests(config):
     ctd_file = app_name+constants.TKL_CTD_TEST_PLAN_FILE_SUFFIX
 
     # generate building-block test sequences
-    if config['generate']['ctd_amplified']['reuse_base_tests']:
+    reuse_sequences = config['generate']['ctd_amplified']['reuse_base_tests']
+
+    if reuse_sequences:
+        if (test_generator_name == constants.COMBINED_TEST_GENERATOR_NAME and \
+            (not os.path.isfile(app_name+"_RandoopTestGenerator"+constants.TKL_BB_SEQ_FILE_SUFFIX) \
+                or not os.path.isfile(app_name+"_EvoSuiteTestGenerator"+constants.TKL_BB_SEQ_FILE_SUFFIX))) \
+                or (test_generator_name != constants.COMBINED_TEST_GENERATOR_NAME and
+                    not os.path.isfile(app_name + "_" + test_generator_name + constants.TKL_BB_SEQ_FILE_SUFFIX)):
+                    tkltest_status("Basic block test sequence files do not exist, generating from scratch")
+                    reuse_sequences = False
+
+    if reuse_sequences:
         tkltest_status("Reusing existing basic block test sequences")
     else:
         run_bb_test_generator(app_name, ctd_file, monolith_app_path, app_classpath_file,


### PR DESCRIPTION

## Description

When reuse_base_tests is given but no sequence files exist, generate them instead of crashing

Related to #118 

## Type of Change

Please check the types of changes your PR introduces.

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactoring (non-breaking code restructuring that preserves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build-related update (CI workflow, test cases)
- [ ] Documentation update
- [ ] Other (please describe):

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so that it can be replicated.
Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
