### PR TITLE
Issue 137 infer monolith app path Ant

### DIFF
--- a/test/data/84_ifx-framework/build.xml
+++ b/test/data/84_ifx-framework/build.xml
@@ -13,7 +13,7 @@
   </path>
 <!-- Environment variables -->
   <target name="setup" description="Setting environment variables">
-    <property name="build.dir" value="classes" />
+    <property name="build.dir" value="." />
     <property name="src.dir" value="src" />
     <property name="src-gen.dir" value="src-gen" />
     <property name="test.dir" value="test" />

--- a/test/data/84_ifx-framework/build.xml
+++ b/test/data/84_ifx-framework/build.xml
@@ -13,7 +13,7 @@
   </path>
 <!-- Environment variables -->
   <target name="setup" description="Setting environment variables">
-    <property name="build.dir" value="build" />
+    <property name="build.dir" value="classes" />
     <property name="src.dir" value="src" />
     <property name="src-gen.dir" value="src-gen" />
     <property name="test.dir" value="test" />

--- a/test/data/84_ifx-framework/tkltest_config.toml
+++ b/test/data/84_ifx-framework/tkltest_config.toml
@@ -2,7 +2,7 @@ name = "TKLTEST_CONFIG_FILE"
 
 [general]
     app_name = "84_ifx-framework"
-    monolith_app_path = ["test/data/84_ifx-framework/classes"]
+    monolith_app_path = ["test/data/84_ifx-framework"]
     java_jdk_home = ""
 
 [generate]

--- a/test/data/irs/monolith/build.xml
+++ b/test/data/irs/monolith/build.xml
@@ -1,7 +1,7 @@
 <project name="irs" default="compile-classpath-attribute" basedir=".">
 
   <!-- The directories for compilation targets -->
-  <property name="build.home"              value="build"/>
+  <property name="build.home"              value="target"/>
   <property name="build.classes"           value="${build.home}/classes"/>
 	
   <!-- The base directories for sources -->

--- a/test/data/irs/monolith/for_tests_build.xml
+++ b/test/data/irs/monolith/for_tests_build.xml
@@ -1,5 +1,6 @@
 <project name="irs" default="compile-classpath-attribute" basedir=".">
-
+    <!-- This build.xml was written for test purposes, should not be used to compile the app! -->
+    
   <!-- The directories for compilation targets -->
   <property name="build.home"              value="target"/>
   <property name="build.classes"           value="${build.home}/classes"/>
@@ -19,6 +20,11 @@
   
   <pathconvert refid="source.lib"
                property="source.lib.property" />
+    
+    <path id="build.classes.pathid" path="target/classes" />
+    
+    <pathconvert refid="build.classes.pathid"
+               property="build.classes.refid" />
   
 
   <path id="source.lib.only.javax">
@@ -54,7 +60,7 @@
 <!-- ====================================================================== -->
 
   <target name="compile-classpath-attribute" depends="prepare"
-          description="Compile main code passing classpath attribute to javac">
+          description="Compile main code passing classpath attribute to javac, destdir is a property">
     <delete dir="${build.classes}"/>
     <mkdir dir="${build.classes}"/>
     <javac  srcdir="${source.java}"
@@ -66,22 +72,21 @@
 
     
   <target name="compile-classpathref-attribute" depends="prepare"
-          description="Compile main code passing classpathref attribute to javac">
+          description="Compile main code passing classpathref attribute to javac, destdir is a relative path">
     <delete dir="${build.classes}"/>
     <mkdir dir="${build.classes}"/>
     <javac  srcdir="${source.java}"
-           destdir="${build.classes}"
+           destdir="target/classes"
             includeantruntime="no"
           classpathref="source.lib"/>
   </target>
     
     
   <target name="compile-classpath-element" depends="prepare"
-          description="Compile main code passing classpath nested element to javac">
+          description="For test, will not compile! destdir not specified - equals to srcdir">
     <delete dir="${build.classes}"/>
     <mkdir dir="${build.classes}"/>
-    <javac  srcdir="${source.java}"
-           destdir="${build.classes}"
+    <javac  srcdir="${build.classes}"
             includeantruntime="no">
           <classpath>
               <path refid="source.lib.only.javax"/>
@@ -92,7 +97,38 @@
           </classpath>
     </javac>          
   </target>
+    
+    
+    <target name="compile-destdir-through-modulesourcepath" depends="prepare"
+          description="For test, will not compile! destdir not specified - equals to modulesourcepath">
+    <delete dir="${build.classes}"/>
+    <mkdir dir="${build.classes}"/>
+    <javac  modulesourcepath="${build.classes}"
+            includeantruntime="no"
+            classpathref="source.lib"/>
+  </target>
   
+
+<target name="compile-destdir-through-modulesourcepathref" depends="prepare"
+          description="For test, will not compile! destdir not specified - equals to modulesourcepathref">
+    <delete dir="${build.classes}"/>
+    <mkdir dir="${build.classes}"/>
+    <javac  modulesourcepathref="build.classes.pathid"
+            includeantruntime="no"
+            classpathref="source.lib"/>     
+  </target>
+
+<target name="compile-destdir-through-src-elements" depends="prepare"
+          description="For test, will not compile! destdir not specified - equals to modulesourcepathref">
+    <delete dir="${build.classes}"/>
+    <mkdir dir="${build.classes}"/>
+    <javac  includeantruntime="no"
+            classpathref="source.lib">
+            <src path="${build.classes}/nonexistent_dir" />
+            <src path="${build.classes}/irs" />
+    </javac>          
+  </target>
+
 <!-- ====================================================================== -->    
   
 </project>


### PR DESCRIPTION
## Description

Given the application's Ant build file, automatically extract the monolith app path.
This is done by creating a modified copy of the build file and replacing the javac tasks with echo tasks that print the app path, calling Ant command and parsing the output afterwards.

Related to #137

## Type of Change

Please check the types of changes your PR introduces.

- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Refactoring (non-breaking code restructuring that preserves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build-related update (CI workflow, test cases)
- [ ] Documentation update
- [ ] Other (please describe):

## How Has This Been Tested?

Unit tests were written with different test cases for specifying the app path in Ant build files.

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
