### PR TITLE
Selenium API duplicate path tests

### DIFF
--- a/tkltest/generate/ui/generate_selenium.py
+++ b/tkltest/generate/ui/generate_selenium.py
@@ -82,15 +82,17 @@ def generate_selenium_api_tests(config, crawl_dir):
     }
 
     # iterate over crawl paths and construct context for each test method
-    method_names = []
+    method_name_count = {}
     for path_num, crawl_path in enumerate(crawl_paths):
         # for each path create a jinja context for the test method to be generated
         method_name = __create_method_name_for_path(crawl_path)
         logging.info('Path {}: length={}, {}'.format(path_num, len(crawl_path), method_name))
-        if method_name in method_names:
-            logging.warning('Found duplicate crawl path: {} ... skipping'.format(method_name))
-            continue
-        method_names.append(method_name)
+        if method_name in method_name_count:
+            method_name_count[method_name] = method_name_count[method_name] + 1
+            method_name = '{}_dup{}'.format(method_name, method_name_count[method_name])
+            logging.info('Creating duplicate test method: {}'.format(method_name))
+        else:
+            method_name_count[method_name] = 0
         method_context = {
             'priority': path_num,
             'name': method_name,
@@ -223,10 +225,11 @@ if __name__ == '__main__':  # pragma: no cover
     logging_util.init_logging('generate_selenium.log', 'INFO')
     app_config = {
         'general': {
+            'log-level': 'WARNING',
             # 'app_name': 'petclinic',
             # 'app_url': 'http://localhost:8080'
-            'app_name': 'addressbook',
-            'app_url': 'http://localhost:3000/addressbook/'
+            # 'app_name': 'addressbook',
+            # 'app_url': 'http://localhost:3000/addressbook/'
         },
         'generate': {
             'browser': 'chrome_headless',


### PR DESCRIPTION
## Description

This PR contains updates to Selenium API test generator to create test methods for duplicate crawl paths, with `_dup*` suffix added to the test method name.

Related to # (issue)

## Type of Change

Please check the types of changes your PR introduces.

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Refactoring (non-breaking code restructuring that preserves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build-related update (CI workflow, test cases)
- [ ] Documentation update
- [ ] Other (please describe):

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so that it can be replicated.
Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
