### PR TITLE
Fixed exclusion of generate option on config init

### DIFF
--- a/tkltest/util/unit/config_options_unit.py
+++ b/tkltest/util/unit/config_options_unit.py
@@ -316,8 +316,8 @@ __options_spec = {
             'is_toml_option': True,
             'is_cli_option': False,
             'type': str,
-            'choices': ['gradle', 'ant', 'maven', None],
-            'default_value': None,
+            'choices': ['gradle', 'ant', 'maven', ''],
+            'default_value': '',
             'help_message': 'build type for collecting app dependencies: ant, maven, or gradle'
         },
         'app_build_files': {


### PR DESCRIPTION
## Description

This PR fixes a bug that caused the generate command option `app_build_type` to be excluded on config init

Related to #225 

## Type of Change

Please check the types of changes your PR introduces.

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactoring (non-breaking code restructuring that preserves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build-related update (CI workflow, test cases)
- [ ] Documentation update
- [ ] Other (please describe):

## How Has This Been Tested?

Checked manually and using CI tests

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
