### PR TITLE
Issue 111 print a warning when using unrecognized flags

### DIFF
--- a/test/unit/test_cli.bats
+++ b/test/unit/test_cli.bats
@@ -115,12 +115,14 @@ teardown_file() {
 @test "Test 12: CLI generate ctd-amplified invalid spec in toml" {
     run tkltest-unit --config-file $IRS_CONFIG_FILE_ERR generate ctd-amplified
     assert_failure 1
-    assert_line --index 1 --partial 'ERROR: configuration options validation failed:'
-    assert_line --index 2 --partial "Missing required options for \"general\": ['app_name']"
-    assert_line --index 3 --partial "Missing conditionally required option for \"general\": monolith_app_path (required if \"app_build_type\" is not specified)"
-    assert_line --index 4 --partial "Value for option \"build_type\" must be one of ['ant', 'maven', 'gradle']: cpp"
-    assert_line --index 5 --partial "Missing conditionally required option for \"generate\": app_build_type (required if \"monolith_app_path\" is not specified)"
-    assert_line --index 6 --partial "Value for option \"base_test_generator\" must be one of ['combined', 'evosuite', 'randoop']: combine"
+    assert_line --index 1 --partial "Warning: Ignoring unrecognized flag"
+    assert_line --index 2 --partial "Warning: Ignoring unrecognized flag"
+    assert_line --index 3 --partial "ERROR: configuration options validation failed:"
+    assert_line --index 4 --partial "Missing required options for \"general\": ['app_name']"
+    assert_line --index 5 --partial "Missing conditionally required option for \"general\": monolith_app_path (required if \"app_build_type\" is not specified)"
+    assert_line --index 6 --partial "Value for option \"build_type\" must be one of ['ant', 'maven', 'gradle']: cpp"
+    assert_line --index 7 --partial "Missing conditionally required option for \"generate\": app_build_type (required if \"monolith_app_path\" is not specified)"
+    assert_line --index 8 --partial "Value for option \"base_test_generator\" must be one of ['combined', 'evosuite', 'randoop']: combine"
 }
 
 @test "Test 13: CLI generate ctd-amplified no config" {
@@ -133,24 +135,28 @@ teardown_file() {
     run tkltest-unit --config-file $IRS_CONFIG_FILE_ERR \
         generate --partitions-file $IRS_PARTITIONS_FILE ctd-amplified
     assert_failure 1
-    assert_line --index 1 --partial "ERROR: configuration options validation failed:"
-    assert_line --index 2 --partial "Missing required options for \"general\": ['app_name']"
-    assert_line --index 3 --partial "Missing conditionally required option for \"general\": monolith_app_path (required if \"app_build_type\" is not specified)"
-    assert_line --index 4 --partial "Value for option \"build_type\" must be one of ['ant', 'maven', 'gradle']: cpp"
-    assert_line --index 5 --partial "Missing conditionally required option for \"generate\": app_build_type (required if \"monolith_app_path\" is not specified)"
-    assert_line --index 6 --partial "refactored_app_path_prefix (required if \"partitions_file\" is specified)"
-    assert_line --index 7 --partial "refactored_app_path_suffix (required if \"partitions_file\" is specified)"
-    assert_line --index 8 --partial "Value for option \"base_test_generator\" must be one of ['combined', 'evosuite', 'randoop']: combine"
+    assert_line --index 1 --partial "Warning: Ignoring unrecognized flag"
+    assert_line --index 2 --partial "Warning: Ignoring unrecognized flag"
+    assert_line --index 3 --partial "ERROR: configuration options validation failed:"
+    assert_line --index 4 --partial "Missing required options for \"general\": ['app_name']"
+    assert_line --index 5 --partial "Missing conditionally required option for \"general\": monolith_app_path (required if \"app_build_type\" is not specified)"
+    assert_line --index 6 --partial "Value for option \"build_type\" must be one of ['ant', 'maven', 'gradle']: cpp"
+    assert_line --index 7 --partial "Missing conditionally required option for \"generate\": app_build_type (required if \"monolith_app_path\" is not specified)"
+    assert_line --index 8 --partial "refactored_app_path_prefix (required if \"partitions_file\" is specified)"
+    assert_line --index 9 --partial "refactored_app_path_suffix (required if \"partitions_file\" is specified)"
+    assert_line --index 10 --partial "Value for option \"base_test_generator\" must be one of ['combined', 'evosuite', 'randoop']: combine"
 }
 
 @test "Test 15: CLI execute invalid spec in toml" {
     run tkltest-unit --config-file $IRS_CONFIG_FILE_ERR execute
     assert_failure 1
-    assert_line --index 1 --partial "ERROR: configuration options validation failed:"
-    assert_line --index 2 --partial "Missing required options for \"general\": ['app_name']"
-    assert_line --index 3 --partial "Missing conditionally required option for \"general\": monolith_app_path (required if \"app_build_type\" is not specified)"
-    assert_line --index 4 --partial "Value for option \"build_type\" must be one of ['ant', 'maven', 'gradle']: cpp"
-    assert_line --index 5 --partial "Missing required options for \"execute\": ['app_packages']"
+    assert_line --index 1 --partial "Warning: Ignoring unrecognized flag"
+    assert_line --index 2 --partial "Warning: Ignoring unrecognized flag"
+    assert_line --index 3 --partial "ERROR: configuration options validation failed:"
+    assert_line --index 4 --partial "Missing required options for \"general\": ['app_name']"
+    assert_line --index 5 --partial "Missing conditionally required option for \"general\": monolith_app_path (required if \"app_build_type\" is not specified)"
+    assert_line --index 6 --partial "Value for option \"build_type\" must be one of ['ant', 'maven', 'gradle']: cpp"
+    assert_line --index 7 --partial "Missing required options for \"execute\": ['app_packages']"
 
 }
 
@@ -166,17 +172,23 @@ teardown_file() {
     run tkltest-unit --config-file $IRS_CONFIG_FILE \
         --test-directory $IRS_CTD_AMPLIFIED_TESTDIR execute
     assert_failure 1
-    assert_line --index 1 --partial "Executing tests for app irs using config file"
-    assert_line --index 2 --partial "Generate config file not found:"
-    assert_line --index 3 --partial "To execute tests in ../$IRS_CTD_AMPLIFIED_TESTDIR, the file created by the generate command must be available"
+    assert_line --index 1 --partial "Warning: Ignoring unrecognized flag"
+    assert_line --index 2 --partial "Warning: Ignoring unrecognized flag"
+    assert_line --index 3 --partial "Warning: Ignoring unrecognized flag"
+    assert_line --index 4 --partial "Executing tests for app irs using config file"
+    assert_line --index 5 --partial "Generate config file not found:"
+    assert_line --index 6 --partial "To execute tests in ../$IRS_CTD_AMPLIFIED_TESTDIR, the file created by the generate command must be available"
 }
 
 @test "Test 17: CLI generate ctd-amplified parameter constraint violation" {
     run tkltest-unit --config-file $IRS_CONFIG_FILE generate ctd-amplified \
         --base-test-generator randoop
     assert_failure 1
-    assert_line --index 1 --partial "ERROR: configuration options validation failed:"
-    assert_line --index 2 --partial "Violated parameter constraint: For coverage augmentation, base test generator must be \"combined\" or \"evosuite\""
+    assert_line --index 1 --partial "Warning: Ignoring unrecognized flag"
+    assert_line --index 2 --partial "Warning: Ignoring unrecognized flag"
+    assert_line --index 3 --partial "Warning: Ignoring unrecognized flag"
+    assert_line --index 4 --partial "ERROR: configuration options validation failed:"
+    assert_line --index 5 --partial "Violated parameter constraint: For coverage augmentation, base test generator must be \"combined\" or \"evosuite\""
 }
 
 @test "Test 18: CLI generate ctd-amplified invalid build/classpath spec in toml" {

--- a/test/unit/test_cli.bats
+++ b/test/unit/test_cli.bats
@@ -115,8 +115,8 @@ teardown_file() {
 @test "Test 12: CLI generate ctd-amplified invalid spec in toml" {
     run tkltest-unit --config-file $IRS_CONFIG_FILE_ERR generate ctd-amplified
     assert_failure 1
-    assert_line --index 1 --partial "Warning: Ignoring unrecognized flag"
-    assert_line --index 2 --partial "Warning: Ignoring unrecognized flag"
+    assert_line --index 1 --partial "Warning: Unsupported flag in toml file"
+    assert_line --index 2 --partial "Warning: Unsupported flag in toml file"
     assert_line --index 3 --partial "ERROR: configuration options validation failed:"
     assert_line --index 4 --partial "Missing required options for \"general\": ['app_name']"
     assert_line --index 5 --partial "Missing conditionally required option for \"general\": monolith_app_path (required if \"app_build_type\" is not specified)"
@@ -135,8 +135,8 @@ teardown_file() {
     run tkltest-unit --config-file $IRS_CONFIG_FILE_ERR \
         generate --partitions-file $IRS_PARTITIONS_FILE ctd-amplified
     assert_failure 1
-    assert_line --index 1 --partial "Warning: Ignoring unrecognized flag"
-    assert_line --index 2 --partial "Warning: Ignoring unrecognized flag"
+    assert_line --index 1 --partial "Warning: Unsupported flag in toml file"
+    assert_line --index 2 --partial "Warning: Unsupported flag in toml file"
     assert_line --index 3 --partial "ERROR: configuration options validation failed:"
     assert_line --index 4 --partial "Missing required options for \"general\": ['app_name']"
     assert_line --index 5 --partial "Missing conditionally required option for \"general\": monolith_app_path (required if \"app_build_type\" is not specified)"
@@ -150,8 +150,8 @@ teardown_file() {
 @test "Test 15: CLI execute invalid spec in toml" {
     run tkltest-unit --config-file $IRS_CONFIG_FILE_ERR execute
     assert_failure 1
-    assert_line --index 1 --partial "Warning: Ignoring unrecognized flag"
-    assert_line --index 2 --partial "Warning: Ignoring unrecognized flag"
+    assert_line --index 1 --partial "Warning: Unsupported flag in toml file"
+    assert_line --index 2 --partial "Warning: Unsupported flag in toml file"
     assert_line --index 3 --partial "ERROR: configuration options validation failed:"
     assert_line --index 4 --partial "Missing required options for \"general\": ['app_name']"
     assert_line --index 5 --partial "Missing conditionally required option for \"general\": monolith_app_path (required if \"app_build_type\" is not specified)"
@@ -172,9 +172,9 @@ teardown_file() {
     run tkltest-unit --config-file $IRS_CONFIG_FILE \
         --test-directory $IRS_CTD_AMPLIFIED_TESTDIR execute
     assert_failure 1
-    assert_line --index 1 --partial "Warning: Ignoring unrecognized flag"
-    assert_line --index 2 --partial "Warning: Ignoring unrecognized flag"
-    assert_line --index 3 --partial "Warning: Ignoring unrecognized flag"
+    assert_line --index 1 --partial "Warning: Unsupported flag in toml file"
+    assert_line --index 2 --partial "Warning: Unsupported flag in toml file"
+    assert_line --index 3 --partial "Warning: Unsupported flag in toml file"
     assert_line --index 4 --partial "Executing tests for app irs using config file"
     assert_line --index 5 --partial "Generate config file not found:"
     assert_line --index 6 --partial "To execute tests in ../$IRS_CTD_AMPLIFIED_TESTDIR, the file created by the generate command must be available"
@@ -184,9 +184,9 @@ teardown_file() {
     run tkltest-unit --config-file $IRS_CONFIG_FILE generate ctd-amplified \
         --base-test-generator randoop
     assert_failure 1
-    assert_line --index 1 --partial "Warning: Ignoring unrecognized flag"
-    assert_line --index 2 --partial "Warning: Ignoring unrecognized flag"
-    assert_line --index 3 --partial "Warning: Ignoring unrecognized flag"
+    assert_line --index 1 --partial "Warning: Unsupported flag in toml file"
+    assert_line --index 2 --partial "Warning: Unsupported flag in toml file"
+    assert_line --index 3 --partial "Warning: Unsupported flag in toml file"
     assert_line --index 4 --partial "ERROR: configuration options validation failed:"
     assert_line --index 5 --partial "Violated parameter constraint: For coverage augmentation, base test generator must be \"combined\" or \"evosuite\""
 }

--- a/tkltest/util/config_util.py
+++ b/tkltest/util/config_util.py
@@ -273,15 +273,20 @@ def __update_config_with_cli_value(config, options_spec, args):
                     config[opt_name] = opt_value
 
 
-def __merge_config(base_config, update_config):
+def __merge_config(base_config, update_config, key_prefix=""):
     """Merge two config specs.
 
     Updates base config with data in update config.
+    Prints warnings about unrecognized configuration flags from update config, and doesn't add them to base config.
     """
     for key, val in update_config.items():
+        full_key = key if key_prefix == "" else key_prefix + '.' + key
+        if key not in base_config:
+            tkltest_status('Warning: Ignoring unrecognized flag from toml file: {}'.format(full_key))
+            continue
         if isinstance(val, dict):
             baseval = base_config.setdefault(key, {})
-            __merge_config(baseval, val)
+            __merge_config(baseval, val, full_key)
         else:
             base_config[key] = val
 

--- a/tkltest/util/config_util.py
+++ b/tkltest/util/config_util.py
@@ -277,7 +277,7 @@ def __merge_config(base_config, update_config, key_prefix=""):
     """Merge two config specs.
 
     Updates base config with data in update config.
-    Prints warnings about unrecognized configuration flags from update config, and doesn't add them to base config.
+    Prints warnings about unrecognized configuration flags from update_config, still adds them to base_config.
     """
     for key, val in update_config.items():
         full_key = key if key_prefix == "" else key_prefix + '.' + key

--- a/tkltest/util/config_util.py
+++ b/tkltest/util/config_util.py
@@ -282,8 +282,7 @@ def __merge_config(base_config, update_config, key_prefix=""):
     for key, val in update_config.items():
         full_key = key if key_prefix == "" else key_prefix + '.' + key
         if key not in base_config:
-            tkltest_status('Warning: Ignoring unrecognized flag from toml file: {}'.format(full_key))
-            continue
+            tkltest_status('Warning: Unsupported flag in toml file: {}'.format(full_key))
         if isinstance(val, dict):
             baseval = base_config.setdefault(key, {})
             __merge_config(baseval, val, full_key)


### PR DESCRIPTION
## Description
When the toml file specifies an unsupported flag, a warning message is printed.
The unsupported flag is not ignored.

Related to issue 111 in Planning repo

## Type of Change

Please check the types of changes your PR introduces.

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Refactoring (non-breaking code restructuring that preserves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build-related update (CI workflow, test cases)
- [ ] Documentation update
- [ ] Other (please describe):

## How Has This Been Tested?

With local runs of tkltest-unit and tkltest-ui on different toml files.
Bats tests were updated to check this feature.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
