### PR TITLE
Update Tackle-Test-Core jars when downloading Java library dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ tkltest-ui --help
 
 > Notes on upgrading an installation:
 > - If you download a newer TackleTest release, follow the [command installation instructions](doc/installation.md#installing-the-tackletest-cli) and check the TackleTest version by running the command `tkltest-unit -v` or `tkltest-ui -v`.
-> - To pull in updated [published library dependencies](https://github.com/orgs/konveyor/packages?repo_name=tackle-test-generator-core) for the [TackleTest Core](https://github.com/konveyor/tackle-test-generator-core) components, please make sure to delete the corresponding jar files from `lib/download` as well as from your local Maven repository (`~/.m2/repository`) before [running the download script](./doc/installation.md#downloading-java-library-dependencies).
+> - If you upgrade the repo snapshot, please be sure to [rerun the download script](./doc/installation.md#downloading-java-library-dependencies) to pull in the updated [published library dependencies](https://github.com/orgs/konveyor/packages?repo_name=tackle-test-generator-core) for the [TackleTest Core](https://github.com/konveyor/tackle-test-generator-core) components.
 
 ## TackleTest CLI in action on sample apps
 

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -14,8 +14,8 @@ requires authentication. To enable authentication, create a [GitHub personal acc
 with the permission `read:packages`. Note that using your GitHub password will not work for downloading some
 of the jar files; a personal access token must be used.
 
-Updatde the script [../lib/download_lib_jars.sh](../lib/download_lib_jars.sh) by replace `GITHUB_USERNAME` with your GitHub username and `GITHUB_TOKEN` with the personal access token that you created. Then, run the script to download all
-library dependencies.
+Update the settings file [../lib/settings.xml](../lib/settings.xml) by replacing `GITHUB_USERNAME` with your GitHub username and `GITHUB_TOKEN` with the personal access token that you created.
+Then, run the `lib/download_lib_jars.sh` script to download all library dependencies.
 
 ```buildoutcfg
 cd lib; ./download_lib_jars.sh
@@ -26,7 +26,7 @@ Windows users should run:
 cd lib; download_lib_jars.sh
 ```
    
-This downloads the Java libraries required by the CLI into the `lib/download` directory.
+This downloads the Java libraries required by the CLI into the `lib/download` directory, including the updated versions of `tackle-test-generator-core` jars.
 
 TackleTest-Unit performs CTD modeling and test-plan generation using the [NIST Automated Combinatorial Testing for Software](https://csrc.nist.gov/projects/automated-combinatorial-testing-for-software) tool, which is packaged with the CLI (in the `lib` directory).
 

--- a/lib/download_lib_jars.sh
+++ b/lib/download_lib_jars.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
-
+rm -r ~/.m2/repository/org/konveyor/tackle-test-generator-unit/
+rm -r ~/.m2/repository/org/konveyor/tackle-test-generator-ui/
 mvn -s ./settings.xml -q download:wget@get-randoop-jar download:wget@get-replacecall-jar download:wget@get-evosuite-jar download:wget@get-evosuite-runtime-jar
 mvn -s ./settings.xml -q dependency:copy-dependencies -DoutputDirectory=./download

--- a/lib/download_lib_jars.sh
+++ b/lib/download_lib_jars.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+
 rm -r ~/.m2/repository/org/konveyor/tackle-test-generator-unit/
 rm -r ~/.m2/repository/org/konveyor/tackle-test-generator-ui/
 mvn -s ./settings.xml -q download:wget@get-randoop-jar download:wget@get-replacecall-jar download:wget@get-evosuite-jar download:wget@get-evosuite-runtime-jar


### PR DESCRIPTION
## Description

Before, running `download_lib_jars.sh` didn't update the jars of tkltest-core (`tackle-test-generator-unit-x.x.x.jar` and `tackle-test-generator-unit-x.x.x.jar`) in `lib/download`.
Updated the `download_lib_jars.sh` script to remove those jars from the m2 directory, which updates the jars in `lib/download`, so the cli runs with the updated version of the core.

Related to # (issue)

## Type of Change

Please check the types of changes your PR introduces.

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactoring (non-breaking code restructuring that preserves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Build-related update (CI workflow, test cases)
- [ ] Documentation update
- [ ] Other (please describe):

## How Has This Been Tested?

Running the script locally redownloads the tackle-core jars in `lib/download`.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
