### PR TITLE
Issue 112 allow fails during augmentation

### DIFF
--- a/tkltest/generate/unit/augment.py
+++ b/tkltest/generate/unit/augment.py
@@ -220,10 +220,7 @@ def __compute_base_and_augmenting_tests_coverage(ctd_test_dir, evosuite_test_dir
                                       raw_cov_data_dir=raw_cov_data_dir, jdk_path=jdk_path)
         if not test_coverage:
             tkltest_status('Error while computing coverage for test: {}'.format(test), error=True)
-            __initialize_test_directory(ctd_test_dir=ctd_test_dir, source_test_dir=ctd_test_dir_bak)
-            sys.exit(1)
-
-        if test_coverage['instruction_covered'] > 0:
+        elif test_coverage['instruction_covered'] > 0:
             has_coverage = True
         coverage_util.remove_test_class_from_ctd_suite(test_class=test, test_directory=ctd_test_dir)
 
@@ -361,6 +358,8 @@ def __compute_tests_with_coverage_gain(test_class_augment_pool, ctd_test_dir, ba
         test_raw_cov_file = os.path.join(raw_cov_dir,
                                          os.path.basename(test_class)[:-5]+constants.JACOCO_SUFFIX_FOR_AUGMENTATION)
 
+        if not os.path.isfile(test_raw_cov_file):
+            continue
         # get coverage delta for test class against base CTD coverage
         try:
             coverage_delta, total_coverage = coverage_util.get_delta_coverage(test=test_class,
@@ -447,7 +446,8 @@ def __augment_ctd_test_suite(tests_with_coverage_gain, ctd_test_dir, base_ctd_co
 
             test_raw_cov_file = os.path.join(raw_cov_dir,
                                         os.path.basename(test_class)[:-5] + constants.JACOCO_SUFFIX_FOR_AUGMENTATION)
-
+            if not os.path.isfile(test_raw_cov_file):
+                continue
             try:
                 coverage_delta, augmented_coverage = coverage_util.get_delta_coverage(
                     test=test_class, test_raw_cov_file=test_raw_cov_file,

--- a/tkltest/util/unit/coverage_util.py
+++ b/tkltest/util/unit/coverage_util.py
@@ -65,7 +65,12 @@ def get_coverage_for_test_suite(build_file, build_type, test_root_dir, report_di
     env_vars = dict(os.environ.copy())
     env_vars['JAVA_HOME'] = jdk_path
     if has_test_suite:
-    # run tests using build file
+        jacoco_raw_data_file = get_jacoco_exec_file(build_type, test_root_dir)
+        try:
+            os.remove(jacoco_raw_data_file)
+        except OSError:
+            pass
+        # run tests using build file to get the .exec file
         if build_type == 'ant':
             cmd = "ant -f {} merge-coverage-report".format(build_file)
         elif build_type == 'maven':
@@ -76,11 +81,11 @@ def get_coverage_for_test_suite(build_file, build_type, test_root_dir, report_di
             command_util.run_command(cmd, verbose=False, env_vars=env_vars)
         except subprocess.CalledProcessError as e:
             tkltest_status('Error while running test suite for coverage computing: {}\n{}'.format(e, e.stderr), error=True)
-            return None
-        jacoco_raw_data_file = get_jacoco_exec_file(build_type, test_root_dir)
         if not os.path.exists(jacoco_raw_data_file):
             tkltest_status('{} was not created by : {}'.format(jacoco_raw_data_file, cmd), error=True)
-            return None
+            # we allow error when trying to get test suite coverage.
+            # will handle it like we do not have test files at all:
+            jacoco_raw_data_file = ''
 
     if additional_test_suite:
         '''
@@ -226,10 +231,25 @@ def get_delta_coverage(test, test_raw_cov_file, ctd_raw_cov_file, main_coverage_
         except OSError:
             pass
 
+    no_delta_coverage = {
+        'instruction_cov_delta': 0,
+        'line_cov_delta': 0,
+        'branch_cov_delta': 0,
+        'method_cov_delta': 0
+        }, {
+        'instruction_covered': base_coverage['instruction_covered'],
+        'line_covered': base_coverage['line_covered'],
+        'branch_covered': base_coverage['branch_covered'],
+        'method_covered': base_coverage['method_covered'],
+        'instruction_total': base_coverage['instruction_total'],
+        'line_total': base_coverage['line_total'],
+        'branch_total': base_coverage['branch_total'],
+        'method_total': base_coverage['method_total']}
+
     jacoco_cli_file = os.path.join(constants.TKLTEST_LIB_DOWNLOAD_DIR, constants.JACOCO_CLI_JAR_NAME)
     env_vars = dict(os.environ.copy())
     env_vars['JAVA_HOME'] = jdk_path
-    if os.path.isfile(ctd_raw_cov_file):
+    if os.path.isfile(ctd_raw_cov_file) and os.path.isfile(test_raw_cov_file):
         try:
             command_util.run_command("java -Xmx"+str(max_memory)+"m -jar {} merge {} {} --destfile {}".
                                  format(jacoco_cli_file, test_raw_cov_file, ctd_raw_cov_file,
@@ -238,32 +258,29 @@ def get_delta_coverage(test, test_raw_cov_file, ctd_raw_cov_file, main_coverage_
             # If merging failed we skip current test file and assume it resulted in zero delta coverage
             # The reason to continue is that we may still gain from previous augmenting test files
             tkltest_status('Warning: merging of jacoco output failed, skipping current test file: {}\n{}'.format(e, e.stderr))
-            return {
-                       'instruction_cov_delta': 0,
-                       'line_cov_delta': 0,
-                       'branch_cov_delta': 0,
-                       'method_cov_delta': 0
-                   }, {'instruction_covered': base_coverage['instruction_covered'],
-                       'line_covered': base_coverage['line_covered'],
-                       'branch_covered': base_coverage['branch_covered'],
-                       'method_covered': base_coverage['method_covered'],
-                       'instruction_total': base_coverage['instruction_total'],
-                       'line_total': base_coverage['line_total'],
-                       'branch_total': base_coverage['branch_total'],
-                       'method_total': base_coverage['method_total']}
-    else:
+            return no_delta_coverage
+    elif os.path.isfile(test_raw_cov_file):
         shutil.copy(test_raw_cov_file, output_exec_file)
+    else:
+        tkltest_status('Warning: file {} does not exist'.format(test_raw_cov_file))
+        return no_delta_coverage
     # run jacoco cli report command
+    if not os.path.isdir(main_coverage_dir):
+        os.makedirs(main_coverage_dir)
     coverage_csv_file = os.path.join(main_coverage_dir, os.path.basename(test)) + '.csv'
     coverage_xml_file = os.path.join(main_coverage_dir, 'jacoco.xml')
 
     jacoco_classfiles_ops = ''
     for classpath in class_files:
         jacoco_classfiles_ops += '--classfiles {} '.format(classpath)
-    command_util.run_command("java -jar {} report {} {} --csv {} --html {} --xml {}".
-                             format(jacoco_cli_file, output_exec_file, jacoco_classfiles_ops,
-                                    coverage_csv_file, main_coverage_dir, coverage_xml_file),
-                             verbose=True, env_vars=env_vars)
+    try:
+        create_report_command ="java -jar {} report {} {} --csv {} --html {} --xml {}".format(
+            jacoco_cli_file, output_exec_file, jacoco_classfiles_ops,
+            coverage_csv_file, main_coverage_dir, coverage_xml_file)
+        command_util.run_command(create_report_command, verbose=True, env_vars=env_vars)
+    except subprocess.CalledProcessError as e:
+        tkltest_status('Generating coverage report failed, skipping current test file {}: {}\n{}'.format(create_report_command, e, e.stderr),error=True)
+        return no_delta_coverage
 
     # read the coverage CSV file and compute total instruction, line, and branch coverage
     total_inst_covered = 0


### PR DESCRIPTION
## Description
we allow all kinds of fails of during augmentation:
1. failing tests
2. compilation/run time errors.
3. report creation error, merge exec files error

in all cases, augmentation continue as if there is no coverage of the relevant test files

Please include a summary of the change and the issue that the PR is related to.
Please also include relevant motivation and context.
List any dependencies that are required for this change.

Related to # 112

## Type of Change

Please check the types of changes your PR introduces.

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactoring (non-breaking code restructuring that preserves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build-related update (CI workflow, test cases)
- [ ] Documentation update
- [ ] Other (please describe):

## How Has This Been Tested?
Durin debug, I inserted compilation/tests failures, and make sure that augmentation finish as accepted.

Please describe the tests that you ran to verify your changes. Provide instructions so that it can be replicated.
Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
