### PR TITLE
Maven build to complete its execution also when there are test failures

### DIFF
--- a/tkltest/util/unit/build_util.py
+++ b/tkltest/util/unit/build_util.py
@@ -433,6 +433,7 @@ def __build_maven(classpath_list, app_name, monolith_app_paths, test_root_dir, t
                         line('artifactId', 'maven-surefire-plugin')
                         line('version', constants.MAVEN_SURFIRE_VERSION)
                         with tag('configuration'):
+                            line('testFailureIgnore', 'true')
                             line('reportsDirectory', junit_output_dir + '/raw')
                             with tag('systemPropertyVariables'):
                                 line('jacoco-agent.destfile', os.path.join(os.path.abspath(test_src_dir), 'jacoco.exec'))

--- a/tkltest/util/unit/coverage_util.py
+++ b/tkltest/util/unit/coverage_util.py
@@ -89,6 +89,10 @@ def get_coverage_for_test_suite(build_file, build_type, test_root_dir, report_di
             # we allow error when trying to get test suite coverage.
             # will handle it like we do not have test files at all:
             jacoco_raw_data_file = ''
+        elif not os.path.exists(coverage_csv_file):
+            tkltest_status('Warning: {} was not created by : {}.\n Skipping current test file'.format(coverage_csv_file, cmd))
+            # if csv file was not created, we will not use the jacoco file
+            jacoco_raw_data_file = ''
 
     if additional_test_suite:
         '''


### PR DESCRIPTION
## Description
1. it seems that maven did not ignore failures.
2. handle the case in which an exec file was created, but not a csv file

Please include a summary of the change and the issue that the PR is related to.
Please also include relevant motivation and context.
List any dependencies that are required for this change.

Related to 118

## Type of Change

Please check the types of changes your PR introduces.

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactoring (non-breaking code restructuring that preserves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build-related update (CI workflow, test cases)
- [ ] Documentation update
- [ ] Other (please describe):

## How Has This Been Tested?
bug was reconstructed and fixed on irs, and lfsm (madihas app)

Please describe the tests that you ran to verify your changes. Provide instructions so that it can be replicated.
Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
