### PR TITLE
Terminate augmentation with intermediate results when memory is exhausted 

### DIFF
--- a/tkltest/generate/unit/augment.py
+++ b/tkltest/generate/unit/augment.py
@@ -80,7 +80,7 @@ def augment_with_code_coverage(config, build_file, build_type, ctd_test_dir, rep
         tkltest_status('Failed to collect coverage for tests in the augmentation test pool, no tests are added.')
         return False
 
-    tkltest_status('Collecting coverage gain for each of {} tests in the augmentation test pool'.format(
+    tkltest_status('Collecting coverage gain for each of {} test files in the augmentation test pool'.format(
         len(test_class_augment_pool)))
 
     # initialize map for test classes that provide coverage gain
@@ -206,6 +206,12 @@ def __compute_base_and_augmenting_tests_coverage(ctd_test_dir, evosuite_test_dir
         for dir, files in coverage_util.get_test_classes(evosuite_test_dir).items()
         for file in files if '_scaffolding' not in file
     ]
+
+    if len(augmentation_test_pool) == 0:
+        tkltest_status('Warning: no EvoSuite tests found for augmentation')
+    else:
+        tkltest_status('Computing individual coverage for each of {} test files in the augmentation test pool'
+                   .format(len(augmentation_test_pool)))
 
     counter = 1
     has_coverage = False

--- a/tkltest/generate/unit/augment.py
+++ b/tkltest/generate/unit/augment.py
@@ -393,7 +393,11 @@ def __compute_tests_with_coverage_gain(test_class_augment_pool, ctd_test_dir, ba
             else:
                 logging.info('No coverage gain from test class {}'.format(test_class))
         except subprocess.CalledProcessError as e:
-            logging.error('Error running augmented test suite with class {}: {}'.format(test_class, e))
+            logging.error('Warning: error occurred while merging augmented test suite with class {}: {}'.format(test_class, e))
+
+        if not coverage_delta and not total_coverage:
+            tkltest_status('Terminating augmentation due to memory exhaustion')
+            return tests_with_coverage_gain, total_inst_cov_gain, total_branch_cov_gain
 
         # remove test class from test suite
         #coverage_util.remove_test_class_from_ctd_suite(test_class=test_class, test_directory=ctd_test_dir)
@@ -469,7 +473,12 @@ def __augment_ctd_test_suite(tests_with_coverage_gain, ctd_test_dir, base_ctd_co
                     max_memory=max_memory, jdk_path=jdk_path)
                 first = False
             except subprocess.CalledProcessError as e:
-                logging.error('Error merging augmented test suite with class {}: {}'.format(test_class, e))
+                logging.error('Warning: error occurred while merging augmented test suite with class {}: {}'.format(test_class, e))
+
+            if not coverage_delta and not augmented_coverage:
+                tkltest_status('Terminating augmentation due to memory exhaustion')
+                coverage_util.remove_test_class_from_ctd_suite(test_class=test_class, test_directory=ctd_test_dir)
+                return curr_coverage, added_test_classes
 
             if coverage_delta['instruction_cov_delta'] > 0 or coverage_delta['branch_cov_delta'] > 0:
                 curr_coverage = augmented_coverage

--- a/tkltest/util/unit/coverage_util.py
+++ b/tkltest/util/unit/coverage_util.py
@@ -262,10 +262,10 @@ def get_delta_coverage(test, test_raw_cov_file, ctd_raw_cov_file, main_coverage_
                                  format(jacoco_cli_file, test_raw_cov_file, ctd_raw_cov_file,
                                         output_exec_file), verbose=True, env_vars=env_vars)
         except subprocess.CalledProcessError as e:
-            # If merging failed we skip current test file and assume it resulted in zero delta coverage
-            # The reason to continue is that we may still gain from previous augmenting test files
-            tkltest_status('Warning: merging of jacoco output failed, skipping current test file: {}\n{}'.format(e, e.stderr))
-            return no_delta_coverage
+            # If merging failed we stop augmentation because subsequent merging will most probably also fail due
+            # to same memory issues
+            tkltest_status('Warning: merging of jacoco output failed for test file: {}\n{}'.format(e, e.stderr))
+            return {},{}
     elif os.path.isfile(test_raw_cov_file):
         shutil.copy(test_raw_cov_file, output_exec_file)
     else:


### PR DESCRIPTION
## Description

When memory is exhausted during to jacoco merge, augmentation keeps running, trying to merge the next test coverage, and hitting again and again the same memory exhaustion. Instead, it now terminates with intermediate augmented test suite and coverage results when encountering the first jacoco merge failure.

In addition, added clear messages for the case that EvoSuite tests are not found, and for the number of test files to be iterated in the augmentation pool.

Related to # (issue)

## Type of Change

Please check the types of changes your PR introduces.

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactoring (non-breaking code restructuring that preserves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build-related update (CI workflow, test cases)
- [ ] Documentation update
- [x] Other (please describe): better logging

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so that it can be replicated.
Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
