### PR TITLE
verbose errors in Automatically obtaining modules

### DIFF
--- a/tkltest/util/config_util.py
+++ b/tkltest/util/config_util.py
@@ -1044,7 +1044,7 @@ def get_modules_properties(tkltest_user_config):
                 tkltest_status('running {} command "{}" failed: {}\n{}'.
                                format(app_build_type, get_modules_command, e, e.stderr), error=True)
                 try:
-                    tkltest_status('command output without --quite:')
+                    tkltest_status('Command to obtain modules from user build files failed with the following output:')
                     get_modules_command = get_modules_command.replace('--quiet', '')
                     get_modules_command = get_modules_command.replace(' >> ' + modules_properties_file, '')
                     command_util.run_command(command=get_modules_command, verbose=True)


### PR DESCRIPTION
## Description

verbose errors in Automatically obtaining modules:
1. reporting on modules w/o app dir
2. outputing maven command
Related to # 310

## Type of Change

Please check the types of changes your PR introduces.

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Refactoring (non-breaking code restructuring that preserves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build-related update (CI workflow, test cases)
- [ ] Documentation update
- [ ] Other (please describe):

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so that it can be replicated.
Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
